### PR TITLE
Add async support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\TimeWarp\Halt\Async` (This is an internal feature for `innmind/async` that may introduce BC breaks in next minor versions)
+
 ## 4.0.0 - 2025-04-20
 
 ### Changed

--- a/src/Async/Resumable.php
+++ b/src/Async/Resumable.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\TimeWarp\Async;
+
+use Innmind\Immutable\{
+    Attempt,
+    SideEffect,
+};
+
+/**
+ * @internal
+ * @psalm-immutable
+ */
+final class Resumable
+{
+    /**
+     * @param Attempt<SideEffect> $result
+     */
+    private function __construct(
+        private Attempt $result,
+    ) {
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param Attempt<SideEffect> $result
+     */
+    public static function of(Attempt $result): self
+    {
+        return new self($result);
+    }
+
+    /**
+     * @return Attempt<SideEffect>
+     */
+    public function unwrap(): Attempt
+    {
+        return $this->result;
+    }
+}

--- a/src/Async/Suspended.php
+++ b/src/Async/Suspended.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\TimeWarp\Async;
+
+use Innmind\TimeContinuum\{
+    Clock,
+    PointInTime,
+    Period,
+};
+use Innmind\Immutable\{
+    Attempt,
+    SideEffect,
+};
+
+/**
+ * @internal
+ */
+final class Suspended
+{
+    /**
+     * @psalm-mutation-free
+     */
+    private function __construct(
+        private PointInTime $at,
+        private Period $period,
+    ) {
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function of(
+        PointInTime $at,
+        Period $period,
+    ): self {
+        return new self($at, $period);
+    }
+
+    /**
+     * @param Attempt<SideEffect> $result
+     */
+    public function next(
+        Clock $clock,
+        Attempt $result,
+    ): self|Resumable {
+        $error = $result->match(
+            static fn() => true,
+            static fn() => false,
+        );
+
+        if ($error) {
+            // The drawback of resuming with the error is that an error occuring
+            // due to another Fiber will affect all of them as for now there is
+            // no way to distinguish due to which Fiber the halt failed.
+            // This will need real world experience to know if this approach is
+            // ok or not.
+            return Resumable::of($result);
+        }
+
+        $resumable = $clock
+            ->now()
+            ->elapsedSince($this->at)
+            ->longerThan($this->period->asElapsedPeriod());
+
+        if ($resumable) {
+            return Resumable::of($result);
+        }
+
+        return $this;
+    }
+}

--- a/src/Async/Suspended.php
+++ b/src/Async/Suspended.php
@@ -69,4 +69,12 @@ final class Suspended
 
         return $this;
     }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function period(): Period
+    {
+        return $this->period;
+    }
 }

--- a/src/Halt/Async.php
+++ b/src/Halt/Async.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\TimeWarp\Halt;
+
+use Innmind\TimeWarp\{
+    Halt,
+    Async\Suspended,
+    Async\Resumable,
+};
+use Innmind\TimeContinuum\{
+    Clock,
+    Period,
+};
+use Innmind\Immutable\Attempt;
+
+/**
+ * @internal
+ */
+final class Async implements Halt
+{
+    private function __construct(
+        private Clock $clock,
+    ) {
+    }
+
+    #[\Override]
+    public function __invoke(Period $period): Attempt
+    {
+        /** @var Resumable */
+        $return = \Fiber::suspend(Suspended::of(
+            $this->clock->now(),
+            $period,
+        ));
+
+        return $return->unwrap();
+    }
+
+    public static function of(Clock $clock): self
+    {
+        return new self($clock);
+    }
+}


### PR DESCRIPTION
This is intended for the new [`innmind/async` package](https://github.com/Innmind/async/pull/1).

The value returned by the Fiber suspension contains everything to halt synchronously and combine it with other fibers' suspension. And it also self contain if the Fiber can be resumed or not depending on the result of the synchronous halt.