### PR TITLE
Fix async implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Internal async implementation
+
 ## 4.1.0 - 2025-08-17
 
 ### Added

--- a/src/Async/Suspended.php
+++ b/src/Async/Suspended.php
@@ -47,8 +47,8 @@ final class Suspended
         Attempt $result,
     ): self|Resumable {
         $error = $result->match(
-            static fn() => true,
             static fn() => false,
+            static fn() => true,
         );
 
         if ($error) {


### PR DESCRIPTION
There was 2 problems:

- the check for errors was inversed
- the remaining period calculation was based on the assumption there would be an intermediate `next` call that would advance the `lastChecked` value

The remaining period is computed on the time the `next` method is called.

---

If 2 fibers were started at the same time, one halting for 4 seconds and the other one for 1. Then the second one would finish and when calling `next` on the first one then the `lastChecked` would still be the start time and thus would say it still remains 4 seconds, despite the fact already 1 second had passed.